### PR TITLE
メインメニューを縦方向のレイアウトに変更し，様々なデバイスで正しく表示されるようにする

### DIFF
--- a/app/src/main/res/layout/main_fragment.xml
+++ b/app/src/main/res/layout/main_fragment.xml
@@ -10,16 +10,16 @@
     <Button
         android:id="@+id/button_sales"
         style="@style/MainMenuButton"
-        android:text="販売" />
+        android:text="@string/manage_sales" />
 
     <Button
         android:id="@+id/button_records"
         style="@style/MainMenuButton"
-        android:text="売上管理" />
+        android:text="@string/manage_records" />
 
     <Button
         android:id="@+id/button_stock"
         style="@style/MainMenuButton"
-        android:text="在庫管理" />
+        android:text="@string/manage_stock" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/main_fragment.xml
+++ b/app/src/main/res/layout/main_fragment.xml
@@ -12,19 +12,15 @@
 
         <Button
             android:id="@+id/button_sales"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
+            style="@style/MainMenuButton"
             android:text="販売"
-            android:textSize="50sp"
             app:layout_constraintDimensionRatio="16:9"
             app:layout_constraintWidth_percent="0.4" />
 
 
         <Button
             android:id="@+id/button_records"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_marginTop="30dp"
+            style="@style/MainMenuButton"
             android:text="売上管理"
             android:textSize="50sp"
             app:layout_constraintDimensionRatio="16:9"
@@ -33,9 +29,7 @@
 
         <Button
             android:id="@+id/button_stock"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_marginTop="30dp"
+            style="@style/MainMenuButton"
             android:text="在庫管理"
             android:textSize="50sp"
             app:layout_constraintDimensionRatio="16:9"
@@ -43,17 +37,18 @@
 
 
         <androidx.constraintlayout.helper.widget.Flow
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:constraint_referenced_ids="button_records,button_sales,button_stock"
             app:flow_horizontalBias="0.5"
-            app:flow_horizontalStyle="packed"
             app:flow_horizontalGap="10dp"
+            app:flow_horizontalStyle="packed"
             app:flow_maxElementsWrap="2"
-            app:flow_wrapMode="chain" />
+            app:flow_verticalGap="10dp"
+            app:flow_wrapMode="chain"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/main_fragment.xml
+++ b/app/src/main/res/layout/main_fragment.xml
@@ -4,42 +4,57 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <Button
-        android:id="@+id/button_sales"
-        android:layout_width="399dp"
-        android:layout_height="217dp"
-        android:text="販売"
-        android:textSize="90sp"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.1" />
+        app:layout_constraintTop_toTopOf="parent">
 
-    <Button
-        android:id="@+id/button_records"
-        android:layout_width="399dp"
-        android:layout_height="217dp"
-        android:text="売上管理"
-        android:textSize="60sp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.1"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.9" />
+        <Button
+            android:id="@+id/button_sales"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:text="販売"
+            android:textSize="50sp"
+            app:layout_constraintDimensionRatio="16:9"
+            app:layout_constraintWidth_percent="0.4" />
 
-    <Button
-        android:id="@+id/button_stock"
-        android:layout_width="399dp"
-        android:layout_height="217dp"
-        android:text="在庫管理"
-        android:textSize="60sp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.9"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.9" />
+
+        <Button
+            android:id="@+id/button_records"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginTop="30dp"
+            android:text="売上管理"
+            android:textSize="50sp"
+            app:layout_constraintDimensionRatio="16:9"
+            app:layout_constraintWidth_percent="0.4" />
+
+
+        <Button
+            android:id="@+id/button_stock"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginTop="30dp"
+            android:text="在庫管理"
+            android:textSize="50sp"
+            app:layout_constraintDimensionRatio="16:9"
+            app:layout_constraintWidth_percent="0.4" />
+
+
+        <androidx.constraintlayout.helper.widget.Flow
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:constraint_referenced_ids="button_records,button_sales,button_stock"
+            app:flow_horizontalBias="0.5"
+            app:flow_horizontalStyle="packed"
+            app:flow_horizontalGap="10dp"
+            app:flow_maxElementsWrap="2"
+            app:flow_wrapMode="chain" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/main_fragment.xml
+++ b/app/src/main/res/layout/main_fragment.xml
@@ -1,55 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical"
+    android:paddingStart="20dp"
+    android:paddingEnd="20dp">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+    <Button
+        android:id="@+id/button_sales"
+        style="@style/MainMenuButton"
+        android:text="販売" />
 
-        <Button
-            android:id="@+id/button_sales"
-            style="@style/MainMenuButton"
-            android:text="販売"
-            app:layout_constraintDimensionRatio="16:9"
-            app:layout_constraintWidth_percent="0.4" />
+    <Button
+        android:id="@+id/button_records"
+        style="@style/MainMenuButton"
+        android:text="売上管理" />
 
+    <Button
+        android:id="@+id/button_stock"
+        style="@style/MainMenuButton"
+        android:text="在庫管理" />
 
-        <Button
-            android:id="@+id/button_records"
-            style="@style/MainMenuButton"
-            android:text="売上管理"
-            android:textSize="50sp"
-            app:layout_constraintDimensionRatio="16:9"
-            app:layout_constraintWidth_percent="0.4" />
-
-
-        <Button
-            android:id="@+id/button_stock"
-            style="@style/MainMenuButton"
-            android:text="在庫管理"
-            android:textSize="50sp"
-            app:layout_constraintDimensionRatio="16:9"
-            app:layout_constraintWidth_percent="0.4" />
-
-
-        <androidx.constraintlayout.helper.widget.Flow
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:constraint_referenced_ids="button_records,button_sales,button_stock"
-            app:flow_horizontalBias="0.5"
-            app:flow_horizontalGap="10dp"
-            app:flow_horizontalStyle="packed"
-            app:flow_maxElementsWrap="2"
-            app:flow_verticalGap="10dp"
-            app:flow_wrapMode="chain"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-</androidx.constraintlayout.widget.ConstraintLayout>
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,5 +20,8 @@
     <string name="back">戻る</string>
     <string name="delete">削除</string>
     <string name="refresh">refresh</string>
+    <string name="manage_stock">在庫管理</string>
+    <string name="manage_records">売上管理</string>
+    <string name="manage_sales">販売</string>
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+</resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,3 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <style name="MainMenuButton">
+        <item name="android:layout_width">0dp</item>
+        <item name="android:layout_height">0dp</item>
+        <item name="android:textSize">50sp</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="MainMenuButton">
-        <item name="android:layout_width">0dp</item>
-        <item name="android:layout_height">0dp</item>
+        <item name="android:layout_width">400dp</item>
+        <item name="android:height">200dp</item>
+        <item name="android:layout_height">wrap_content</item>
         <item name="android:textSize">50sp</item>
     </style>
 </resources>


### PR DESCRIPTION
メインメニューをシンプルな縦方向レイアウトに変更します．

## スクリーンショット
機種 | スクショ
:--: | :--:
Tablet | <img width="300" alt="Screenshot 2023-07-02 at 23 07 21" src="https://github.com/kameryo/CRFPOS/assets/48154936/a5f18bf2-dc55-4d24-9ed0-699d94801f6c">
Phone | <img width="200" alt="Screenshot 2023-07-02 at 23 07 34" src="https://github.com/kameryo/CRFPOS/assets/48154936/caf1b7e0-ba4e-428a-a471-f270d4a24fda">
Foldable | <img width="300" alt="Screenshot 2023-07-02 at 23 07 47" src="https://github.com/kameryo/CRFPOS/assets/48154936/3359dc63-ef93-4201-bf74-e241fc5b1536">

## 追加の変更
レイアウト中で使われているstringリソースをstrings.xmlへ抽出します．
