### PR TITLE
Fix: some goods not being displayed in SummarizeGoodsScreen

### DIFF
--- a/feature/feature-record/src/main/java/com/example/feature_record/SummarizeGoodsViewModel.kt
+++ b/feature/feature-record/src/main/java/com/example/feature_record/SummarizeGoodsViewModel.kt
@@ -46,8 +46,11 @@ class SummarizeGoodsViewModel @Inject constructor(
                     val quantity = cartItem.quantity
 
                     // 商品ごとの集計を更新
-                    val summary = summaryMap.getOrPut(goods.displayOrder.toLong()) {
-                        GoodsSalesSummary(goodsId = goods.displayOrder.toLong(), goodsName = goods.name)
+                    val summary = summaryMap.getOrPut(goods.id) {
+                        GoodsSalesSummary(
+                            goodsId = goods.id,
+                            goodsName = goods.name
+                        )
                     }
                     summary.totalQuantity += quantity
                 }


### PR DESCRIPTION
As the title says, some goods were not visible in SummarizeGoodsScreen.

When multiple goods shared the same displayOrder, their information was not grouped correctly.
This happened because the key of summaryMap was displayOrder instead of id.

This PR fixes the issue by using id as the key for summaryMap.

Before | After
:--: | :--:
<img width="2208" height="1768" alt="image" src="https://github.com/user-attachments/assets/df796698-19cd-411a-bd74-210cdd63abf7" /> | <img width="2208" height="1768" alt="image" src="https://github.com/user-attachments/assets/4edc453f-ec58-4da8-a739-34bbc40c75b7" />
